### PR TITLE
Suggestions for PyLong_Import/Export API

### DIFF
--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -552,17 +552,17 @@ Import/Export API
    A single unsigned digit.
 
    It is usually used in an *array of digits*, such as the
-   :c:member:`PyLong_DigitArray.digits` array.
+   :c:member:`PyUnstable_Long_DigitArray.digits` array.
 
    Its size depend on the :c:macro:`!PYLONG_BITS_IN_DIGIT` macro:
    see the ``configure`` :option:`--enable-big-digits` option.
 
-   See :c:member:`PyLong_LAYOUT.bits_per_digit` for the number of bits per
-   digit and :c:member:`PyLong_LAYOUT.digit_size` for the size of a digit (in
+   See :c:member:`PyUnstable_Long_LAYOUT.bits_per_digit` for the number of bits per
+   digit and :c:member:`PyUnstable_Long_LAYOUT.digit_size` for the size of a digit (in
    bytes).
 
 
-.. c:struct:: PyLong_LAYOUT
+.. c:struct:: PyUnstable_Long_LAYOUT
 
    Internal layout of a Python :class:`int` object.
 
@@ -591,29 +591,33 @@ Import/Export API
       - ``-1`` for least significant first (little endian)
 
 
-.. c:function:: PyObject* PyLong_Import(int negative, size_t ndigits, PyLongDigitsArray *long_import)
+.. c:function:: int PyUnstable_Long_Import(int negative, size_t ndigits, PyUnstable_Long_DigitArray *long_import)
 
-   Prepart :c:struct:`PyLongDigitsArray` to hold a Python :class:`int` object
+   Prepare :c:struct:`PyUnstable_Long_DigitArray` to hold a Python
+   :class:`int` object.
 
    *negative* is ``1`` if the number should be negative, or ``0`` otherwise.
 
    *ndigits* is the number of digits in the integer.
 
-   See :c:struct:`PyLong_LAYOUT` for the internal layout of an integer.
+   See :c:struct:`PyUnstable_Long_LAYOUT` for the internal layout of an integer.
 
    * Set *\*long_import and return 0 on success.
    * Set an exception and return -1 on error.
 
-   :c:func:`PyLong_ReleaseImport` must be called once done with using
+   :c:func:`PyUnstable_Long_ReleaseImport` must be called once done with using
    *long_import*.  A strong reference should be taken on *long_import->obj*,
    if this object should be kept after releasing the *long_import*.
 
+.. c:function:: void PyUnstable_Long_ReleaseImport(PyUnstable_Long_DigitArray *long_import)
 
-.. c:struct:: PyLong_DigitsArray
+   Release the *long_import* created by :c:func:`PyUnstable_Long_Import`.
+
+.. c:struct:: PyUnstable_Long_DigitArray
 
    A Python :class:`int` object exported as an array of digits.
 
-   See :c:struct:`PyLong_LAYOUT` for the internal layout of an integer.
+   See :c:struct:`PyUnstable_Long_LAYOUT` for the internal layout of an integer.
 
    .. c:member:: PyLongObject *obj
 
@@ -632,7 +636,7 @@ Import/Export API
       Array of unsigned digits.
 
 
-.. c:function:: int PyLong_Export(PyObject *obj, PyLongDigitsArray *long_export)
+.. c:function:: int PyUnstable_Long_Export(PyObject *obj, PyUnstable_Long_DigitArray *long_export)
 
    Export a Python :class:`int` object as an array of digits.
 
@@ -642,10 +646,10 @@ Import/Export API
    This function always succeeds if *obj* is a Python :class:`int` object or a
    subclass.
 
-   :c:func:`PyLong_ReleaseExport` must be called once done with using
+   :c:func:`PyUnstable_Long_ReleaseExport` must be called once done with using
    *long_export*.
 
 
-.. c:function:: void PyLong_ReleaseExport(PyLongDigitsArray *long_export)
+.. c:function:: void PyUnstable_Long_ReleaseExport(PyUnstanle_Long_DigitArray *long_export)
 
-   Release an export created by :c:func:`Py_Long_Export`.
+   Release the export *long_export* created by :c:func:`PyUnstable_Long_Export`.

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -552,17 +552,17 @@ Import/Export API
    A single unsigned digit.
 
    It is usually used in an *array of digits*, such as the
-   :c:member:`PyUnstable_LongExport.digits` array.
+   :c:member:`PyLongDigitsArray.digits` array.
 
    Its size depend on the :c:macro:`!PYLONG_BITS_IN_DIGIT` macro:
    see the ``configure`` :option:`--enable-big-digits` option.
 
-   See :c:member:`PyUnstable_Long_LAYOUT.bits_per_digit` for the number of bits per
-   digit and :c:member:`PyUnstable_Long_LAYOUT.digit_size` for the size of a digit (in
+   See :c:member:`PyLong_LAYOUT.bits_per_digit` for the number of bits per
+   digit and :c:member:`PyLong_LAYOUT.digit_size` for the size of a digit (in
    bytes).
 
 
-.. c:struct:: PyUnstable_Long_LAYOUT
+.. c:struct:: PyLong_LAYOUT
 
    Internal layout of a Python :class:`int` object.
 
@@ -580,38 +580,40 @@ Import/Export API
 
       Word endian:
 
-      - 1 for most significant byte first (big endian)
-      - 0 for least significant first (little endian)
+      * +1 for most significant byte first (big endian)
+      * -1 for least significant first (little endian)
 
    .. c:member:: int8_t array_endian;
 
       Array endian:
 
-      - 1 for most significant byte first (big endian)
-      - 0 for least significant first (little endian)
+      * +1 for most significant byte first (big endian)
+      * -1 for least significant first (little endian)
 
 
-.. c:function:: PyObject* PyUnstable_Long_Import(int negative, size_t ndigits, Py_digit *digits)
+.. c:function:: PyObject* PyLong_Import(int negative, size_t ndigits, PyLongDigitsArray *long_import)
 
-   Create a Python :class:`int` object from an array of digits.
+   Prepart :c:struct:`PyLongDigitsArray` to hold a Python :class:`int` object
 
-   * Return a Python :class:`int` object on success.
-   * Set an exception and return ``NULL`` on error.
+   *negative* is ``1`` if the number should be negative, or ``0`` otherwise.
 
-   *negative* is ``1`` if the number is negative, or ``0`` otherwise.
+   *ndigits* is the number of digits in the integer.
 
-   *ndigits* is the number of digits in the *digits* array.
+   See :c:struct:`PyLong_LAYOUT` for the internal layout of an integer.
 
-   *digits* is an array of unsigned digits.
+   * Set *\*long_import and return 0 on success.
+   * Set an exception and return -1 on error.
 
-   See :c:struct:`PyUnstable_Long_LAYOUT` for the internal layout of an integer.
+   :c:func:`PyLong_ReleaseImport` must be called once done with using
+   *long_import*.  A strong reference should be taken on *long_import->obj*,
+   if this object should be kept after releasing the *long_import*.
 
 
-.. c:struct:: PyUnstable_LongExport
+.. c:struct:: PyLongDigitsArray
 
    A Python :class:`int` object exported as an array of digits.
 
-   See :c:struct:`PyUnstable_Long_LAYOUT` for the internal layout of an integer.
+   See :c:struct:`PyLong_LAYOUT` for the internal layout of an integer.
 
    .. c:member:: PyLongObject *obj
 
@@ -630,17 +632,17 @@ Import/Export API
       Array of unsigned digits.
 
 
-.. c:function:: int PyUnstable_Long_Export(PyObject *obj, PyUnstable_LongExport *export)
+.. c:function:: int PyLong_Export(PyObject *obj, PyLongDigitsArray *long_export)
 
    Export a Python :class:`int` object as an array of digits.
 
-   * Set *\*export* and return 0 on success.
+   * Set *\*long_export* and return 0 on success.
    * Set an exception and return -1 on error.
 
-   :c:func:`PyUnstable_Long_ReleaseExport` must be called once done with using
-   *export*.
+   :c:func:`PyLong_ReleaseExport` must be called once done with using
+   *long_export*.
 
 
-.. c:function:: void PyUnstable_Long_ReleaseExport(PyUnstable_LongExport *export)
+.. c:function:: void PyLong_ReleaseExport(PyLongDigitsArray *long_export)
 
-   Release an export created by :c:func:`PyUnstable_Long_Export`.
+   Release an export created by :c:func:`Py_Long_Export`.

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -552,7 +552,7 @@ Import/Export API
    A single unsigned digit.
 
    It is usually used in an *array of digits*, such as the
-   :c:member:`PyUnstable_LongExport.digits` array.
+   :c:member:`PyUnstable_Long_DigitArray.digits` array.
 
    Its size depend on the :c:macro:`!PYLONG_BITS_IN_DIGIT` macro:
    see the ``configure`` :option:`--enable-big-digits` option.
@@ -607,11 +607,12 @@ Import/Export API
    See :c:struct:`PyUnstable_Long_LAYOUT` for the internal layout of an integer.
 
 
-.. c:struct:: PyUnstable_LongExport
+.. c:struct:: PyUnstable_Long_DigitArray
 
    A Python :class:`int` object exported as an array of digits.
 
-   See :c:struct:`PyUnstable_Long_LAYOUT` for the internal layout of an integer.
+   See :c:struct:`PyUnstable_Long_LAYOUT` for the internal layout of an
+   integer.
 
    .. c:member:: PyLongObject *obj
 
@@ -630,11 +631,11 @@ Import/Export API
       Array of unsigned digits.
 
 
-.. c:function:: int PyUnstable_Long_Export(PyObject *obj, PyUnstable_LongExport *export)
+.. c:function:: int PyUnstable_Long_Export(PyObject *obj, PyUnstable_Long_DigitArray *array)
 
    Export a Python :class:`int` object as an array of digits.
 
-   * Set *\*export* and return 0 on success.
+   * Set *\*array* and return 0 on success.
    * Set an exception and return -1 on error.
 
    This function always succeeds if *obj* is a Python :class:`int` object or a
@@ -644,6 +645,6 @@ Import/Export API
    *export*.
 
 
-.. c:function:: void PyUnstable_Long_ReleaseExport(PyUnstable_LongExport *export)
+.. c:function:: void PyUnstable_Long_ReleaseExport(PyUnstable_Long_DigitArray *array)
 
-   Release an export created by :c:func:`PyUnstable_Long_Export`.
+   Release the export *array* created by :c:func:`PyUnstable_Long_Export`.

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -637,6 +637,9 @@ Import/Export API
    * Set *\*export* and return 0 on success.
    * Set an exception and return -1 on error.
 
+   This function always succeeds if *obj* is a Python :class:`int` object or a
+   subclass.
+
    :c:func:`PyUnstable_Long_ReleaseExport` must be called once done with using
    *export*.
 

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -554,7 +554,7 @@ Import/Export API
    It is usually used in an *array of digits*, such as the
    :c:member:`PyUnstable_LongExport.digits` array.
 
-   Its size depend on the :c:macro:`PYLONG_BITS_IN_DIGIT` macro:
+   Its size depend on the :c:macro:`!PYLONG_BITS_IN_DIGIT` macro:
    see the ``configure`` :option:`--enable-big-digits` option.
 
    See :c:member:`PyUnstable_Long_LAYOUT.bits_per_digit` for the number of bits per

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -630,7 +630,7 @@ Import/Export API
       Array of unsigned digits.
 
 
-.. c:function:: int PyUnstable_Long_Export(PyLongObject *obj, PyUnstable_LongExport *export)
+.. c:function:: int PyUnstable_Long_Export(PyObject *obj, PyUnstable_LongExport *export)
 
    Export a Python :class:`int` object as an array of digits.
 

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -639,6 +639,9 @@ Import/Export API
    * Set *\*long_export* and return 0 on success.
    * Set an exception and return -1 on error.
 
+   This function always succeeds if *obj* is a :c:type:`PyLongObject`
+   or its subtype.
+
    :c:func:`PyLong_ReleaseExport` must be called once done with using
    *long_export*.
 

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -580,15 +580,15 @@ Import/Export API
 
       Word endian:
 
-      - 1 for most significant byte first (big endian)
-      - 0 for least significant first (little endian)
+      - ``1`` for most significant byte first (big endian)
+      - ``-1`` for least significant first (little endian)
 
    .. c:member:: int8_t array_endian;
 
       Array endian:
 
-      - 1 for most significant byte first (big endian)
-      - 0 for least significant first (little endian)
+      - ``1`` for most significant byte first (big endian)
+      - ``-1`` for least significant first (little endian)
 
 
 .. c:function:: PyObject* PyUnstable_Long_Import(int negative, size_t ndigits, Py_digit *digits)

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -529,6 +529,9 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    Exactly what values are considered compact is an implementation detail
    and is subject to change.
 
+   .. versionadded:: 3.12
+
+
 .. c:function:: Py_ssize_t PyUnstable_Long_CompactValue(const PyLongObject* op)
 
    If *op* is compact, as determined by :c:func:`PyUnstable_Long_IsCompact`,
@@ -536,3 +539,108 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
 
    Otherwise, the return value is undefined.
 
+   .. versionadded:: 3.12
+
+
+Import/Export API
+^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 3.14
+
+.. c:type:: Py_digit
+
+   A single unsigned digit.
+
+   It is usually used in an *array of digits*, such as the
+   :c:member:`PyUnstable_LongExport.digits` array.
+
+   Its size depend on the :c:macro:`PYLONG_BITS_IN_DIGIT` macro:
+   see the ``configure`` :option:`--enable-big-digits` option.
+
+   See :c:member:`PyUnstable_Long_LAYOUT.bits_per_digit` for the number of bits per
+   digit and :c:member:`PyUnstable_Long_LAYOUT.digit_size` for the size of a digit (in
+   bytes).
+
+
+.. c:struct:: PyUnstable_Long_LAYOUT
+
+   Internal layout of a Python :class:`int` object.
+
+   See also :attr:`sys.int_info` which exposes similar information to Python.
+
+   .. c:member:: uint8_t bits_per_digit;
+
+      Bits per digit.
+
+   .. c:member:: uint8_t digit_size;
+
+      Digit size in bytes.
+
+   .. c:member:: int8_t word_endian;
+
+      Word endian:
+
+      - 1 for most significant byte first (big endian)
+      - 0 for least significant first (little endian)
+
+   .. c:member:: int8_t array_endian;
+
+      Array endian:
+
+      - 1 for most significant byte first (big endian)
+      - 0 for least significant first (little endian)
+
+
+.. c:function:: PyObject* PyUnstable_Long_Import(int negative, size_t ndigits, Py_digit *digits)
+
+   Create a Python :class:`int` object from an array of digits.
+
+   * Return a Python :class:`int` object on success.
+   * Set an exception and return ``NULL`` on error.
+
+   *negative* is ``1`` if the number is negative, or ``0`` otherwise.
+
+   *ndigits* is the number of digits in the *digits* array.
+
+   *digits* is an array of unsigned digits.
+
+   See :c:struct:`PyUnstable_Long_LAYOUT` for the internal layout of an integer.
+
+
+.. c:struct:: PyUnstable_LongExport
+
+   A Python :class:`int` object exported as an array of digits.
+
+   See :c:struct:`PyUnstable_Long_LAYOUT` for the internal layout of an integer.
+
+   .. c:member:: PyLongObject *obj
+
+      Strong reference to the Python :class:`int` object.
+
+   .. c:member:: int negative
+
+      1 if the number is negative, 0 otherwise.
+
+   .. c:member:: size_t ndigits
+
+      Number of digits in :c:member:`digits` array.
+
+   .. c:member:: Py_digit *digits
+
+      Array of unsigned digits.
+
+
+.. c:function:: int PyUnstable_Long_Export(PyLongObject *obj, PyUnstable_LongExport *export)
+
+   Export a Python :class:`int` object as an array of digits.
+
+   * Set *\*export* and return 0 on success.
+   * Set an exception and return -1 on error.
+
+   :c:func:`PyUnstable_Long_ReleaseExport` must be called once done with using
+   *export*.
+
+
+.. c:function:: void PyUnstable_Long_ReleaseExport(PyUnstable_LongExport *export)
+
+   Release an export created by :c:func:`PyUnstable_Long_Export`.

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -140,6 +140,8 @@ nitpick_ignore = [
     ('c:type', 'size_t'),
     ('c:type', 'ssize_t'),
     ('c:type', 'time_t'),
+    ('c:type', 'int8_t'),
+    ('c:type', 'uint8_t'),
     ('c:type', 'uint64_t'),
     ('c:type', 'uintmax_t'),
     ('c:type', 'uintptr_t'),

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -129,7 +129,8 @@ General Options
 
    Define the ``PYLONG_BITS_IN_DIGIT`` to ``15`` or ``30``.
 
-   See :data:`sys.int_info.bits_per_digit <sys.int_info>`.
+   See :data:`sys.int_info.bits_per_digit <sys.int_info>` and the
+   :c:type:`Py_digit` type.
 
 .. option:: --with-suffix=SUFFIX
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -343,13 +343,13 @@ New Features
 
   (Contributed by Victor Stinner in :gh:`119182`.)
 
-* Add a new import and export API for Python :class:`int` objects:
+* Add a new unstable import and export API for Python :class:`int` objects:
 
-  * :c:func:`PyLong_Import`;
-  * :c:func:`PyLong_ReleaseImport`;
-  * :c:func:`PyLong_Export`;
-  * :c:func:`PyLong_ReleaseExport`;
-  * :c:struct:`PyLong_LAYOUT`.
+  * :c:func:`PyUnstable_Long_Import`;
+  * :c:func:`PyUnstable_Long_ReleaseImport`;
+  * :c:func:`PyUnstable_Long_Export`;
+  * :c:func:`PyUnstable_Long_ReleaseExport`;
+  * :c:struct:`PyUnstable_Long_LAYOUT`.
 
   (Contributed by Victor Stinner in :gh:`102471`.)
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -343,6 +343,14 @@ New Features
 
   (Contributed by Victor Stinner in :gh:`119182`.)
 
+* Add a new unstable import and export API for Python :class:`int` objects:
+
+  * :c:func:`PyUnstable_Long_Import`;
+  * :c:func:`PyUnstable_Long_Export`;
+  * :c:struct:`PyUnstable_Long_LAYOUT`.
+
+  (Contributed by Victor Stinner in :gh:`102471`.)
+
 Porting to Python 3.14
 ----------------------
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -343,11 +343,13 @@ New Features
 
   (Contributed by Victor Stinner in :gh:`119182`.)
 
-* Add a new unstable import and export API for Python :class:`int` objects:
+* Add a new import and export API for Python :class:`int` objects:
 
-  * :c:func:`PyUnstable_Long_Import`;
-  * :c:func:`PyUnstable_Long_Export`;
-  * :c:struct:`PyUnstable_Long_LAYOUT`.
+  * :c:func:`PyLong_Import`;
+  * :c:func:`PyLong_ReleaseImport`;
+  * :c:func:`PyLong_Export`;
+  * :c:func:`PyLong_ReleaseExport`;
+  * :c:struct:`PyLong_LAYOUT`.
 
   (Contributed by Victor Stinner in :gh:`102471`.)
 

--- a/Include/cpython/longintrepr.h
+++ b/Include/cpython/longintrepr.h
@@ -143,7 +143,7 @@ _PyLong_CompactValue(PyLongObject *op)
 
 /* --- Import/Export API -------------------------------------------------- */
 
-typedef struct PyLongLayout {
+typedef struct PyUnstable_LongLayout {
     // Bits per digit
     uint8_t bits_per_digit;
 
@@ -159,29 +159,29 @@ typedef struct PyLongLayout {
     // - 1 for most significant byte first (big endian)
     // - -1 for least significant first (little endian)
     int8_t array_endian;
-} PyLongLayout;
+} PyUnstable_LongLayout;
 
-PyAPI_DATA(const PyLongLayout) PyLong_LAYOUT;
+PyAPI_DATA(const PyUnstable_LongLayout) PyUnstable_Long_LAYOUT;
 
-typedef struct PyLong_DigitArray {
+typedef struct PyUnstable_Long_DigitArray {
     PyLongObject *obj;
     int negative;
     size_t ndigits;
     Py_digit *digits;
-} PyLong_DigitArray;
+} PyUnstable_Long_DigitArray;
 
-PyAPI_FUNC(int) PyLong_Export(
+PyAPI_FUNC(int) PyUnstable_Long_Export(
     PyObject *obj,
-    PyLong_DigitArray *long_export);
-PyAPI_FUNC(void) PyLong_ReleaseExport(
-    PyLong_DigitArray *long_export);
+    PyUnstable_Long_DigitArray *long_export);
+PyAPI_FUNC(void) PyUnstable_Long_ReleaseExport(
+    PyUnstable_Long_DigitArray *long_export);
 
-PyAPI_FUNC(int) PyLong_Import(
+PyAPI_FUNC(int) PyUnstable_Long_Import(
     int negative,
     size_t ndigits,
-    PyLong_DigitArray *long_import);
-PyAPI_FUNC(void) PyLong_ReleaseImport(
-    PyLong_DigitArray *long_import);
+    PyUnstable_Long_DigitArray *long_import);
+PyAPI_FUNC(void) PyUnstable_Long_ReleaseImport(
+    PyUnstable_Long_DigitArray *long_import);
 
 #ifdef __cplusplus
 }

--- a/Include/cpython/longintrepr.h
+++ b/Include/cpython/longintrepr.h
@@ -61,6 +61,8 @@ typedef long stwodigits; /* signed variant of twodigits */
 #define PyLong_BASE     ((digit)1 << PyLong_SHIFT)
 #define PyLong_MASK     ((digit)(PyLong_BASE - 1))
 
+typedef digit Py_digit;
+
 /* Long integer representation.
 
    Long integers are made up of a number of 30- or 15-bit digits, depending on
@@ -138,6 +140,43 @@ _PyLong_CompactValue(PyLongObject *op)
 
 #define PyUnstable_Long_CompactValue _PyLong_CompactValue
 
+
+/* --- Import/Export API -------------------------------------------------- */
+
+typedef struct PyUnstable_LongLayout {
+    // Bits per digit
+    uint8_t bits_per_digit;
+
+    // Digit size in bytes: sizeof(digit)
+    uint8_t digit_size;
+
+    // Word endian:
+    // - 1 for most significant byte first (big endian)
+    // - 0 for least significant first (little endian)
+    int8_t word_endian;
+
+    // Array endian:
+    // - 1 for most significant byte first (big endian)
+    // - 0 for least significant first (little endian)
+    int8_t array_endian;
+} PyUnstable_LongLayout;
+
+PyAPI_DATA(const PyUnstable_LongLayout) PyUnstable_Long_LAYOUT;
+
+PyAPI_FUNC(PyObject*) PyUnstable_Long_Import(
+    int negative,
+    size_t ndigits,
+    Py_digit *digits);
+
+typedef struct PyUnstable_LongExport {
+    PyLongObject *obj;
+    int negative;
+    size_t ndigits;
+    Py_digit *digits;
+} PyUnstable_LongExport;
+
+PyAPI_FUNC(int) PyUnstable_Long_Export(PyLongObject *obj, PyUnstable_LongExport *export);
+PyAPI_FUNC(void) PyUnstable_Long_ReleaseExport(PyUnstable_LongExport *export);
 
 #ifdef __cplusplus
 }

--- a/Include/cpython/longintrepr.h
+++ b/Include/cpython/longintrepr.h
@@ -143,7 +143,7 @@ _PyLong_CompactValue(PyLongObject *op)
 
 /* --- Import/Export API -------------------------------------------------- */
 
-typedef struct PyUnstable_LongLayout {
+typedef struct PyLongLayout {
     // Bits per digit
     uint8_t bits_per_digit;
 
@@ -151,35 +151,37 @@ typedef struct PyUnstable_LongLayout {
     uint8_t digit_size;
 
     // Word endian:
-    // - 1 for most significant byte first (big endian)
-    // - 0 for least significant first (little endian)
+    // +1 for most significant byte first (big endian)
+    // -1 for least significant first (little endian)
     int8_t word_endian;
 
     // Array endian:
-    // - 1 for most significant byte first (big endian)
-    // - 0 for least significant first (little endian)
+    // +1 for most significant byte first (big endian)
+    // -1 for least significant first (little endian)
     int8_t array_endian;
-} PyUnstable_LongLayout;
+} PyLongLayout;
 
-PyAPI_DATA(const PyUnstable_LongLayout) PyUnstable_Long_LAYOUT;
+PyAPI_DATA(const PyLongLayout) PyLong_LAYOUT;
 
-PyAPI_FUNC(PyObject*) PyUnstable_Long_Import(
-    int negative,
-    size_t ndigits,
-    Py_digit *digits);
-
-typedef struct PyUnstable_LongExport {
+typedef struct PyLongDigitsArray {
     PyLongObject *obj;
     int negative;
     size_t ndigits;
     Py_digit *digits;
-} PyUnstable_LongExport;
+} PyLongDigitsArray;
 
-PyAPI_FUNC(int) PyUnstable_Long_Export(
+PyAPI_FUNC(int) PyLong_Export(
     PyObject *obj,
-    PyUnstable_LongExport *long_export);
-PyAPI_FUNC(void) PyUnstable_Long_ReleaseExport(
-    PyUnstable_LongExport *long_export);
+    PyLongDigitsArray *long_export);
+PyAPI_FUNC(void) PyLong_ReleaseExport(
+    PyLongDigitsArray *long_export);
+
+PyAPI_FUNC(int) PyLong_Import(
+    int negative,
+    size_t ndigits,
+    PyLongDigitsArray *long_import);
+PyAPI_FUNC(void) PyLong_ReleaseImport(
+    PyLongDigitsArray *long_import);
 
 #ifdef __cplusplus
 }

--- a/Include/cpython/longintrepr.h
+++ b/Include/cpython/longintrepr.h
@@ -175,8 +175,11 @@ typedef struct PyUnstable_LongExport {
     Py_digit *digits;
 } PyUnstable_LongExport;
 
-PyAPI_FUNC(int) PyUnstable_Long_Export(PyLongObject *obj, PyUnstable_LongExport *export);
-PyAPI_FUNC(void) PyUnstable_Long_ReleaseExport(PyUnstable_LongExport *export);
+PyAPI_FUNC(int) PyUnstable_Long_Export(
+    PyLongObject *obj,
+    PyUnstable_LongExport *long_export);
+PyAPI_FUNC(void) PyUnstable_Long_ReleaseExport(
+    PyUnstable_LongExport *long_export);
 
 #ifdef __cplusplus
 }

--- a/Include/cpython/longintrepr.h
+++ b/Include/cpython/longintrepr.h
@@ -176,7 +176,7 @@ typedef struct PyUnstable_LongExport {
 } PyUnstable_LongExport;
 
 PyAPI_FUNC(int) PyUnstable_Long_Export(
-    PyLongObject *obj,
+    PyObject *obj,
     PyUnstable_LongExport *long_export);
 PyAPI_FUNC(void) PyUnstable_Long_ReleaseExport(
     PyUnstable_LongExport *long_export);

--- a/Include/cpython/longintrepr.h
+++ b/Include/cpython/longintrepr.h
@@ -152,12 +152,12 @@ typedef struct PyUnstable_LongLayout {
 
     // Word endian:
     // - 1 for most significant byte first (big endian)
-    // - 0 for least significant first (little endian)
+    // - -1 for least significant first (little endian)
     int8_t word_endian;
 
     // Array endian:
     // - 1 for most significant byte first (big endian)
-    // - 0 for least significant first (little endian)
+    // - -1 for least significant first (little endian)
     int8_t array_endian;
 } PyUnstable_LongLayout;
 

--- a/Include/cpython/longintrepr.h
+++ b/Include/cpython/longintrepr.h
@@ -168,18 +168,18 @@ PyAPI_FUNC(PyObject*) PyUnstable_Long_Import(
     size_t ndigits,
     Py_digit *digits);
 
-typedef struct PyUnstable_LongExport {
+typedef struct PyUnstable_Long_DigitArray {
     PyLongObject *obj;
     int negative;
     size_t ndigits;
     Py_digit *digits;
-} PyUnstable_LongExport;
+} PyUnstable_Long_DigitArray;
 
 PyAPI_FUNC(int) PyUnstable_Long_Export(
     PyObject *obj,
-    PyUnstable_LongExport *long_export);
+    PyUnstable_Long_DigitArray *array);
 PyAPI_FUNC(void) PyUnstable_Long_ReleaseExport(
-    PyUnstable_LongExport *long_export);
+    PyUnstable_Long_DigitArray *array);
 
 #ifdef __cplusplus
 }

--- a/Lib/test/test_capi/test_long.py
+++ b/Lib/test/test_capi/test_long.py
@@ -768,6 +768,13 @@ class LongTests(unittest.TestCase):
         self.assertEqual(pylong_export(shift**2 * 3 + shift * 2 + 1),
                          (0, [1, 2, 3]))
 
+        with self.assertRaises(TypeError):
+            pylong_export(1.0)
+        with self.assertRaises(TypeError):
+            pylong_export(0+1j)
+        with self.assertRaises(TypeError):
+            pylong_export("abc")
+
     def test_long_import(self):
         # Test PyLong_Import()
         layout = _testcapi.get_pylong_layout()

--- a/Lib/test/test_capi/test_long.py
+++ b/Lib/test/test_capi/test_long.py
@@ -745,7 +745,7 @@ class LongTests(unittest.TestCase):
         # CRASHES getsign(NULL)
 
     def test_long_layout(self):
-        # Test PyLong_LAYOUT
+        # Test PyUnstable_Long_LAYOUT
         int_info = sys.int_info
         layout = _testcapi.get_pylong_layout()
         expected = {
@@ -757,7 +757,7 @@ class LongTests(unittest.TestCase):
         self.assertEqual(layout, expected)
 
     def test_long_export(self):
-        # Test PyLong_Export()
+        # Test PyUnstable_Long_Export()
         layout = _testcapi.get_pylong_layout()
         shift = 2 ** layout['bits_per_digit']
 
@@ -776,7 +776,7 @@ class LongTests(unittest.TestCase):
             pylong_export("abc")
 
     def test_long_import(self):
-        # Test PyLong_Import()
+        # Test PyUnstable_Long_Import()
         layout = _testcapi.get_pylong_layout()
         shift = 2 ** layout['bits_per_digit']
 

--- a/Lib/test/test_capi/test_long.py
+++ b/Lib/test/test_capi/test_long.py
@@ -749,10 +749,10 @@ class LongTests(unittest.TestCase):
         int_info = sys.int_info
         layout = _testcapi.get_pylong_layout()
         expected = {
-            'array_endian': 0,
+            'array_endian': -1,
             'bits_per_digit': int_info.bits_per_digit,
             'digit_size': int_info.sizeof_digit,
-            'word_endian': 1 if sys.byteorder == 'little' else 0,
+            'word_endian': -1 if sys.byteorder == 'little' else 1,
         }
         self.assertEqual(layout, expected)
 

--- a/Misc/NEWS.d/next/C API/2024-07-03-17-26-53.gh-issue-102471.XpmKYk.rst
+++ b/Misc/NEWS.d/next/C API/2024-07-03-17-26-53.gh-issue-102471.XpmKYk.rst
@@ -1,10 +1,10 @@
-Add a new import and export API for Python :class:`int` objects:
+Add a new unstable import and export API for Python :class:`int` objects:
 
-* :c:func:`PyLong_Import`;
-* :c:func:`PyLong_ReleaseImport`;
-* :c:func:`PyLong_Export`;
-* :c:func:`PyLong_ReleaseExport`;
-* :c:func:`PyLongDigitsArray`;
-* :c:struct:`PyLong_LAYOUT`.
+* :c:func:`PyUnstable_Long_Import`;
+* :c:func:`PyUnstable_Long_ReleaseImport`;
+* :c:func:`PyUnstable_Long_Export`;
+* :c:func:`PyUnstable_Long_ReleaseExport`;
+* :c:func:`PyUnstable_LongDigitArray`;
+* :c:struct:`PyUnstable_Long_LAYOUT`.
 
 Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/C API/2024-07-03-17-26-53.gh-issue-102471.XpmKYk.rst
+++ b/Misc/NEWS.d/next/C API/2024-07-03-17-26-53.gh-issue-102471.XpmKYk.rst
@@ -1,7 +1,10 @@
-Add a new unstable import and export API for Python :class:`int` objects:
+Add a new import and export API for Python :class:`int` objects:
 
-* :c:func:`PyUnstable_Long_Import`;
-* :c:func:`PyUnstable_Long_Export`;
-* :c:struct:`PyUnstable_Long_LAYOUT`.
+* :c:func:`PyLong_Import`;
+* :c:func:`PyLong_ReleaseImport`;
+* :c:func:`PyLong_Export`;
+* :c:func:`PyLong_ReleaseExport`;
+* :c:func:`PyLongDigitsArray`;
+* :c:struct:`PyLong_LAYOUT`.
 
 Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/C API/2024-07-03-17-26-53.gh-issue-102471.XpmKYk.rst
+++ b/Misc/NEWS.d/next/C API/2024-07-03-17-26-53.gh-issue-102471.XpmKYk.rst
@@ -1,0 +1,7 @@
+Add a new unstable import and export API for Python :class:`int` objects:
+
+* :c:func:`PyUnstable_Long_Import`;
+* :c:func:`PyUnstable_Long_Export`;
+* :c:struct:`PyUnstable_Long_LAYOUT`.
+
+Patch by Victor Stinner.

--- a/Modules/_testcapi/long.c
+++ b/Modules/_testcapi/long.c
@@ -127,8 +127,8 @@ pylong_import(PyObject *module, PyObject *args)
     }
     Py_ssize_t ndigits = PyList_GET_SIZE(list);
 
-    PyLong_DigitArray long_import;
-    if (PyLong_Import(negative, ndigits, &long_import) == -1) {
+    PyUnstable_Long_DigitArray long_import;
+    if (PyUnstable_Long_Import(negative, ndigits, &long_import) == -1) {
         return NULL;
     }
 
@@ -150,11 +150,11 @@ pylong_import(PyObject *module, PyObject *args)
 
     PyObject *res = (PyObject *)long_import.obj;
     Py_INCREF(res);
-    PyLong_ReleaseImport(&long_import);
+    PyUnstable_Long_ReleaseImport(&long_import);
     return res;
 
 error:
-    PyLong_ReleaseImport(&long_import);
+    PyUnstable_Long_ReleaseImport(&long_import);
     return NULL;
 }
 
@@ -162,8 +162,8 @@ error:
 static PyObject *
 pylong_export(PyObject *module, PyObject *obj)
 {
-    PyLong_DigitArray long_export;
-    if (PyLong_Export(obj, &long_export) < 0) {
+    PyUnstable_Long_DigitArray long_export;
+    if (PyUnstable_Long_Export(obj, &long_export) < 0) {
         return NULL;
     }
 
@@ -184,11 +184,11 @@ pylong_export(PyObject *module, PyObject *obj)
     }
 
     PyObject *res = Py_BuildValue("(iN)", long_export.negative, digits);
-    PyLong_ReleaseExport(&long_export);
+    PyUnstable_Long_ReleaseExport(&long_export);
     return res;
 
 error:
-    PyLong_ReleaseExport(&long_export);
+    PyUnstable_Long_ReleaseExport(&long_export);
     return NULL;
 }
 
@@ -196,7 +196,7 @@ error:
 static PyObject *
 get_pylong_layout(PyObject *module, PyObject *Py_UNUSED(args))
 {
-    PyLongLayout layout = PyLong_LAYOUT;
+    PyUnstable_LongLayout layout = PyUnstable_Long_LAYOUT;
 
     PyObject *dict = PyDict_New();
     if (dict == NULL) {

--- a/Modules/_testcapi/long.c
+++ b/Modules/_testcapi/long.c
@@ -117,6 +117,146 @@ pylong_aspid(PyObject *module, PyObject *arg)
 }
 
 
+static PyObject *
+pylong_import(PyObject *module, PyObject *args)
+{
+    int negative;
+    PyObject *list;
+    if (!PyArg_ParseTuple(args, "iO!", &negative, &PyList_Type, &list)) {
+        return NULL;
+    }
+    Py_ssize_t ndigits = PyList_GET_SIZE(list);
+
+    Py_digit *digits = PyMem_Malloc(ndigits * sizeof(Py_digit));
+    if (digits == NULL) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+
+    for (Py_ssize_t i=0; i < ndigits; i++) {
+        PyObject *item = PyList_GET_ITEM(list, i);
+
+        long as_long = PyLong_AsLong(item);
+        if (as_long == -1 && PyErr_Occurred()) {
+            goto error;
+        }
+
+        Py_digit digit = (Py_digit)as_long;
+        if ((long)digit != as_long) {
+            PyErr_SetString(PyExc_ValueError, "digit doesn't fit into Py_digit");
+            goto error;
+        }
+        digits[i] = digit;
+    }
+
+    PyObject *res = PyUnstable_Long_Import(negative, ndigits, digits);
+    PyMem_Free(digits);
+
+    return res;
+
+error:
+    PyMem_Free(digits);
+    return NULL;
+}
+
+
+static PyObject *
+pylong_export(PyObject *module, PyObject *obj)
+{
+    if (!PyLong_Check(obj)) {
+        PyErr_Format(PyExc_TypeError, "expect int, got %T", obj);
+        return NULL;
+    }
+
+    PyUnstable_LongExport export;
+    if (PyUnstable_Long_Export((PyLongObject*)obj, &export) < 0) {
+        return NULL;
+    }
+
+    PyObject *digits = PyList_New(0);
+    for (size_t i=0; i < export.ndigits; i++) {
+        PyObject *digit = PyLong_FromUnsignedLong(export.digits[i]);
+        if (digit == NULL) {
+            Py_DECREF(digits);
+            goto error;
+        }
+
+        if (PyList_Append(digits, digit) < 0) {
+            Py_DECREF(digits);
+            Py_DECREF(digit);
+            goto error;
+        }
+        Py_DECREF(digit);
+    }
+
+    PyObject *res = Py_BuildValue("(iN)", export.negative, digits);
+    PyUnstable_Long_ReleaseExport(&export);
+    return res;
+
+error:
+    PyUnstable_Long_ReleaseExport(&export);
+    return NULL;
+}
+
+
+static PyObject *
+get_pylong_layout(PyObject *module, PyObject *Py_UNUSED(args))
+{
+    PyUnstable_LongLayout layout = PyUnstable_Long_LAYOUT;
+
+    PyObject *dict = PyDict_New();
+    if (dict == NULL) {
+        goto error;
+    }
+
+    PyObject *value = PyLong_FromUnsignedLong(layout.bits_per_digit);
+    if (value == NULL) {
+        goto error;
+    }
+    int res = PyDict_SetItemString(dict, "bits_per_digit", value);
+    Py_DECREF(value);
+    if (res < 0) {
+        goto error;
+    }
+
+    value = PyLong_FromUnsignedLong(layout.digit_size);
+    if (value == NULL) {
+        goto error;
+    }
+    res = PyDict_SetItemString(dict, "digit_size", value);
+    Py_DECREF(value);
+    if (res < 0) {
+        goto error;
+    }
+
+    value = PyLong_FromLong(layout.word_endian);
+    if (value == NULL) {
+        goto error;
+    }
+    res = PyDict_SetItemString(dict, "word_endian", value);
+    Py_DECREF(value);
+    if (res < 0) {
+        goto error;
+    }
+
+    value = PyLong_FromLong(layout.array_endian);
+    if (value == NULL) {
+        goto error;
+    }
+    res = PyDict_SetItemString(dict, "array_endian", value);
+    Py_DECREF(value);
+    if (res < 0) {
+        goto error;
+    }
+
+    return dict;
+
+error:
+    Py_XDECREF(dict);
+    return NULL;
+}
+
+
 static PyMethodDef test_methods[] = {
     _TESTCAPI_CALL_LONG_COMPACT_API_METHODDEF
     {"pylong_fromunicodeobject",    pylong_fromunicodeobject,   METH_VARARGS},
@@ -124,6 +264,9 @@ static PyMethodDef test_methods[] = {
     {"pylong_fromnativebytes",      pylong_fromnativebytes,     METH_VARARGS},
     {"pylong_getsign",              pylong_getsign,             METH_O},
     {"pylong_aspid",                pylong_aspid,               METH_O},
+    {"pylong_import",               pylong_import,              METH_VARARGS},
+    {"pylong_export",               pylong_export,              METH_O},
+    {"get_pylong_layout",           get_pylong_layout,          METH_NOARGS},
     {NULL},
 };
 

--- a/Modules/_testcapi/long.c
+++ b/Modules/_testcapi/long.c
@@ -163,13 +163,8 @@ error:
 static PyObject *
 pylong_export(PyObject *module, PyObject *obj)
 {
-    if (!PyLong_Check(obj)) {
-        PyErr_Format(PyExc_TypeError, "expect int, got %T", obj);
-        return NULL;
-    }
-
     PyUnstable_LongExport long_export;
-    if (PyUnstable_Long_Export((PyLongObject*)obj, &long_export) < 0) {
+    if (PyUnstable_Long_Export(obj, &long_export) < 0) {
         return NULL;
     }
 

--- a/Modules/_testcapi/long.c
+++ b/Modules/_testcapi/long.c
@@ -163,14 +163,14 @@ error:
 static PyObject *
 pylong_export(PyObject *module, PyObject *obj)
 {
-    PyUnstable_LongExport long_export;
-    if (PyUnstable_Long_Export(obj, &long_export) < 0) {
+    PyUnstable_Long_DigitArray array;
+    if (PyUnstable_Long_Export(obj, &array) < 0) {
         return NULL;
     }
 
     PyObject *digits = PyList_New(0);
-    for (size_t i=0; i < long_export.ndigits; i++) {
-        PyObject *digit = PyLong_FromUnsignedLong(long_export.digits[i]);
+    for (size_t i=0; i < array.ndigits; i++) {
+        PyObject *digit = PyLong_FromUnsignedLong(array.digits[i]);
         if (digit == NULL) {
             Py_DECREF(digits);
             goto error;
@@ -184,12 +184,12 @@ pylong_export(PyObject *module, PyObject *obj)
         Py_DECREF(digit);
     }
 
-    PyObject *res = Py_BuildValue("(iN)", long_export.negative, digits);
-    PyUnstable_Long_ReleaseExport(&long_export);
+    PyObject *res = Py_BuildValue("(iN)", array.negative, digits);
+    PyUnstable_Long_ReleaseExport(&array);
     return res;
 
 error:
-    PyUnstable_Long_ReleaseExport(&long_export);
+    PyUnstable_Long_ReleaseExport(&array);
     return NULL;
 }
 

--- a/Modules/_testcapi/long.c
+++ b/Modules/_testcapi/long.c
@@ -168,14 +168,14 @@ pylong_export(PyObject *module, PyObject *obj)
         return NULL;
     }
 
-    PyUnstable_LongExport export;
-    if (PyUnstable_Long_Export((PyLongObject*)obj, &export) < 0) {
+    PyUnstable_LongExport long_export;
+    if (PyUnstable_Long_Export((PyLongObject*)obj, &long_export) < 0) {
         return NULL;
     }
 
     PyObject *digits = PyList_New(0);
-    for (size_t i=0; i < export.ndigits; i++) {
-        PyObject *digit = PyLong_FromUnsignedLong(export.digits[i]);
+    for (size_t i=0; i < long_export.ndigits; i++) {
+        PyObject *digit = PyLong_FromUnsignedLong(long_export.digits[i]);
         if (digit == NULL) {
             Py_DECREF(digits);
             goto error;
@@ -189,12 +189,12 @@ pylong_export(PyObject *module, PyObject *obj)
         Py_DECREF(digit);
     }
 
-    PyObject *res = Py_BuildValue("(iN)", export.negative, digits);
-    PyUnstable_Long_ReleaseExport(&export);
+    PyObject *res = Py_BuildValue("(iN)", long_export.negative, digits);
+    PyUnstable_Long_ReleaseExport(&long_export);
     return res;
 
 error:
-    PyUnstable_Long_ReleaseExport(&export);
+    PyUnstable_Long_ReleaseExport(&long_export);
     return NULL;
 }
 

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -6702,26 +6702,26 @@ PyUnstable_Long_Import(int negative, size_t ndigits, Py_digit *digits)
 
 
 int
-PyUnstable_Long_Export(PyLongObject *obj, PyUnstable_LongExport *export)
+PyUnstable_Long_Export(PyLongObject *obj, PyUnstable_LongExport *long_export)
 {
     assert(PyLong_Check(obj));
 
-    export->obj = (PyLongObject*)Py_NewRef(obj);
-    export->negative = _PyLong_IsNegative(obj);
-    export->ndigits = _PyLong_DigitCount(obj);
-    if (export->ndigits == 0) {
-        export->ndigits = 1;
+    long_export->obj = (PyLongObject*)Py_NewRef(obj);
+    long_export->negative = _PyLong_IsNegative(obj);
+    long_export->ndigits = _PyLong_DigitCount(obj);
+    if (long_export->ndigits == 0) {
+        long_export->ndigits = 1;
     }
-    export->digits = obj->long_value.ob_digit;
+    long_export->digits = obj->long_value.ob_digit;
     return 0;
 }
 
 
 void
-PyUnstable_Long_ReleaseExport(PyUnstable_LongExport *export)
+PyUnstable_Long_ReleaseExport(PyUnstable_LongExport *long_export)
 {
-    Py_CLEAR(export->obj);
-    export->negative = 0;
-    export->ndigits = 0;
-    export->digits = NULL;
+    Py_CLEAR(long_export->obj);
+    long_export->negative = 0;
+    long_export->ndigits = 0;
+    long_export->digits = NULL;
 }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -6685,3 +6685,43 @@ Py_ssize_t
 PyUnstable_Long_CompactValue(const PyLongObject* op) {
     return _PyLong_CompactValue((PyLongObject*)op);
 }
+
+const PyUnstable_LongLayout PyUnstable_Long_LAYOUT = {
+    .bits_per_digit = PyLong_SHIFT,
+    .word_endian = PY_LITTLE_ENDIAN,
+    .array_endian = 0,  // least significant first
+    .digit_size = sizeof(digit),
+};
+
+
+PyObject*
+PyUnstable_Long_Import(int negative, size_t ndigits, Py_digit *digits)
+{
+    return (PyObject*)_PyLong_FromDigits(negative, ndigits, digits);
+}
+
+
+int
+PyUnstable_Long_Export(PyLongObject *obj, PyUnstable_LongExport *export)
+{
+    assert(PyLong_Check(obj));
+
+    export->obj = (PyLongObject*)Py_NewRef(obj);
+    export->negative = _PyLong_IsNegative(obj);
+    export->ndigits = _PyLong_DigitCount(obj);
+    if (export->ndigits == 0) {
+        export->ndigits = 1;
+    }
+    export->digits = obj->long_value.ob_digit;
+    return 0;
+}
+
+
+void
+PyUnstable_Long_ReleaseExport(PyUnstable_LongExport *export)
+{
+    Py_CLEAR(export->obj);
+    export->negative = 0;
+    export->ndigits = 0;
+    export->digits = NULL;
+}

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -6702,17 +6702,21 @@ PyUnstable_Long_Import(int negative, size_t ndigits, Py_digit *digits)
 
 
 int
-PyUnstable_Long_Export(PyLongObject *obj, PyUnstable_LongExport *long_export)
+PyUnstable_Long_Export(PyObject *obj, PyUnstable_LongExport *long_export)
 {
-    assert(PyLong_Check(obj));
+    if (!PyLong_Check(obj)) {
+        PyErr_Format(PyExc_TypeError, "expect int, got %T", obj);
+        return -1;
+    }
+    PyLongObject *self = (PyLongObject*)obj;
 
     long_export->obj = (PyLongObject*)Py_NewRef(obj);
-    long_export->negative = _PyLong_IsNegative(obj);
-    long_export->ndigits = _PyLong_DigitCount(obj);
+    long_export->negative = _PyLong_IsNegative(self);
+    long_export->ndigits = _PyLong_DigitCount(self);
     if (long_export->ndigits == 0) {
         long_export->ndigits = 1;
     }
-    long_export->digits = obj->long_value.ob_digit;
+    long_export->digits = self->long_value.ob_digit;
     return 0;
 }
 

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -6688,8 +6688,8 @@ PyUnstable_Long_CompactValue(const PyLongObject* op) {
 
 const PyUnstable_LongLayout PyUnstable_Long_LAYOUT = {
     .bits_per_digit = PyLong_SHIFT,
-    .word_endian = PY_LITTLE_ENDIAN,
-    .array_endian = 0,  // least significant first
+    .word_endian = PY_LITTLE_ENDIAN ? -1 : 1,
+    .array_endian = -1,  // least significant first
     .digit_size = sizeof(digit),
 };
 

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -6686,7 +6686,7 @@ PyUnstable_Long_CompactValue(const PyLongObject* op) {
     return _PyLong_CompactValue((PyLongObject*)op);
 }
 
-const PyLongLayout PyLong_LAYOUT = {
+const PyUnstable_LongLayout PyUnstable_Long_LAYOUT = {
     .bits_per_digit = PyLong_SHIFT,
     .word_endian = PY_LITTLE_ENDIAN ? -1 : 1,
     .array_endian = -1,  // least significant first
@@ -6695,7 +6695,7 @@ const PyLongLayout PyLong_LAYOUT = {
 
 
 int
-PyLong_Import(int negative, size_t ndigits, PyLong_DigitArray *long_import)
+PyUnstable_Long_Import(int negative, size_t ndigits, PyUnstable_Long_DigitArray *long_import)
 {
     PyLongObject *obj;
     if (!(obj = _PyLong_New(ndigits))) {
@@ -6713,7 +6713,7 @@ PyLong_Import(int negative, size_t ndigits, PyLong_DigitArray *long_import)
 
 
 void
-PyLong_ReleaseImport(PyLong_DigitArray *long_import)
+PyUnstable_Long_ReleaseImport(PyUnstable_Long_DigitArray *long_import)
 {
     Py_CLEAR(long_import->obj);
     long_import->negative = 0;
@@ -6724,7 +6724,7 @@ PyLong_ReleaseImport(PyLong_DigitArray *long_import)
 
 
 int
-PyLong_Export(PyObject *obj, PyLong_DigitArray *long_export)
+PyUnstable_Long_Export(PyObject *obj, PyUnstable_Long_DigitArray *long_export)
 {
     if (!PyLong_Check(obj)) {
         PyErr_Format(PyExc_TypeError, "expect int, got %T", obj);
@@ -6744,7 +6744,7 @@ PyLong_Export(PyObject *obj, PyLong_DigitArray *long_export)
 
 
 void
-PyLong_ReleaseExport(PyLong_DigitArray *long_export)
+PyUnstable_Long_ReleaseExport(PyUnstable_Long_DigitArray *long_export)
 {
     Py_CLEAR(long_export->obj);
     long_export->negative = 0;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -6702,7 +6702,7 @@ PyUnstable_Long_Import(int negative, size_t ndigits, Py_digit *digits)
 
 
 int
-PyUnstable_Long_Export(PyObject *obj, PyUnstable_LongExport *long_export)
+PyUnstable_Long_Export(PyObject *obj, PyUnstable_Long_DigitArray *array)
 {
     if (!PyLong_Check(obj)) {
         PyErr_Format(PyExc_TypeError, "expect int, got %T", obj);
@@ -6710,22 +6710,22 @@ PyUnstable_Long_Export(PyObject *obj, PyUnstable_LongExport *long_export)
     }
     PyLongObject *self = (PyLongObject*)obj;
 
-    long_export->obj = (PyLongObject*)Py_NewRef(obj);
-    long_export->negative = _PyLong_IsNegative(self);
-    long_export->ndigits = _PyLong_DigitCount(self);
-    if (long_export->ndigits == 0) {
-        long_export->ndigits = 1;
+    array->obj = (PyLongObject*)Py_NewRef(obj);
+    array->negative = _PyLong_IsNegative(self);
+    array->ndigits = _PyLong_DigitCount(self);
+    if (array->ndigits == 0) {
+        array->ndigits = 1;
     }
-    long_export->digits = self->long_value.ob_digit;
+    array->digits = self->long_value.ob_digit;
     return 0;
 }
 
 
 void
-PyUnstable_Long_ReleaseExport(PyUnstable_LongExport *long_export)
+PyUnstable_Long_ReleaseExport(PyUnstable_Long_DigitArray *array)
 {
-    Py_CLEAR(long_export->obj);
-    long_export->negative = 0;
-    long_export->ndigits = 0;
-    long_export->digits = NULL;
+    Py_CLEAR(array->obj);
+    array->negative = 0;
+    array->ndigits = 0;
+    array->digits = NULL;
 }

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -318,7 +318,7 @@ Objects/exceptions.c	-	static_exceptions	-
 Objects/genobject.c	-	ASYNC_GEN_IGNORED_EXIT_MSG	-
 Objects/genobject.c	-	NON_INIT_CORO_MSG	-
 Objects/longobject.c	-	_PyLong_DigitValue	-
-Objects/longobject.c	-	PyUnstable_Long_LAYOUT	-
+Objects/longobject.c	-	PyLong_LAYOUT	-
 Objects/object.c	-	_Py_SwappedOp	-
 Objects/object.c	-	_Py_abstract_hack	-
 Objects/object.c	-	last_final_reftotal	-

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -318,6 +318,7 @@ Objects/exceptions.c	-	static_exceptions	-
 Objects/genobject.c	-	ASYNC_GEN_IGNORED_EXIT_MSG	-
 Objects/genobject.c	-	NON_INIT_CORO_MSG	-
 Objects/longobject.c	-	_PyLong_DigitValue	-
+Objects/longobject.c	-	PyUnstable_Long_LAYOUT	-
 Objects/object.c	-	_Py_SwappedOp	-
 Objects/object.c	-	_Py_abstract_hack	-
 Objects/object.c	-	last_final_reftotal	-

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -318,7 +318,7 @@ Objects/exceptions.c	-	static_exceptions	-
 Objects/genobject.c	-	ASYNC_GEN_IGNORED_EXIT_MSG	-
 Objects/genobject.c	-	NON_INIT_CORO_MSG	-
 Objects/longobject.c	-	_PyLong_DigitValue	-
-Objects/longobject.c	-	PyLong_LAYOUT	-
+Objects/longobject.c	-	PyUnstable_Long_LAYOUT	-
 Objects/object.c	-	_Py_SwappedOp	-
 Objects/object.c	-	_Py_abstract_hack	-
 Objects/object.c	-	last_final_reftotal	-


### PR DESCRIPTION
* change PyUnstable_Long_Import() to be more like PyUnstable_Long_Export(); importing doesn't require now a temporary buffer for digits
* add PyUnstable_Long_ReleaseImport()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--4.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->