### PR TITLE
Convert decimal module to use PyLongWriter API

### DIFF
--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -3570,12 +3570,13 @@ finish:
 static PyObject *
 dec_as_long(PyObject *dec, PyObject *context, int round)
 {
-    PyLongObject *pylong;
+    PyObject *pylong;
     digit *ob_digit;
     size_t n;
     mpd_t *x;
     mpd_context_t workctx;
     uint32_t status = 0;
+    const PyLongLayout *layout = PyLong_GetNativeLayout();
 
     if (mpd_isspecial(MPD(dec))) {
         if (mpd_isnan(MPD(dec))) {
@@ -3603,34 +3604,36 @@ dec_as_long(PyObject *dec, PyObject *context, int round)
     }
 
     status = 0;
-    ob_digit = NULL;
+    n = (mpd_sizeinbase(x, 2) +
+         layout->bits_per_digit - 1) / layout->bits_per_digit;
+    PyLongWriter *writer = PyLongWriter_Create(mpd_isnegative(x), n,
+                                               (void**)&ob_digit);
+    /* mpd_sizeinbase can overestimate size by 1 digit, set it to zero. */
+    ob_digit[n-1] = 0;
+    if (writer == NULL) {
+        PyLongWriter_Discard(writer);
+        mpd_del(x);
+        return NULL;
+    }
 #if PYLONG_BITS_IN_DIGIT == 30
-    n = mpd_qexport_u32(&ob_digit, 0, PyLong_BASE, x, &status);
+    n = mpd_qexport_u32(&ob_digit, n, PyLong_BASE, x, &status);
 #elif PYLONG_BITS_IN_DIGIT == 15
-    n = mpd_qexport_u16(&ob_digit, 0, PyLong_BASE, x, &status);
+    n = mpd_qexport_u16(&ob_digit, n, PyLong_BASE, x, &status);
 #else
     #error "PYLONG_BITS_IN_DIGIT should be 15 or 30"
 #endif
 
     if (n == SIZE_MAX) {
         PyErr_NoMemory();
+        PyLongWriter_Discard(writer);
         mpd_del(x);
         return NULL;
     }
 
-    if (n == 1) {
-        sdigit val = mpd_arith_sign(x) * ob_digit[0];
-        mpd_free(ob_digit);
-        mpd_del(x);
-        return PyLong_FromLong(val);
-    }
-
     assert(n > 0);
-    assert(!mpd_iszero(x));
-    pylong = _PyLong_FromDigits(mpd_isnegative(x), n, ob_digit);
-    mpd_free(ob_digit);
+    pylong = PyLongWriter_Finish(writer);
     mpd_del(x);
-    return (PyObject *) pylong;
+    return pylong;
 }
 
 /* Convert a Decimal to its exact integer ratio representation. */

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -3604,6 +3604,13 @@ dec_as_long(PyObject *dec, PyObject *context, int round)
     }
 
     status = 0;
+
+    int64_t val = mpd_qget_i64(x, &status);
+    if (!status) {
+        mpd_del(x);
+        return PyLong_FromInt64(val);
+    }
+
     n = (mpd_sizeinbase(x, 2) +
          layout->bits_per_digit - 1) / layout->bits_per_digit;
     PyLongWriter *writer = PyLongWriter_Create(mpd_isnegative(x), n,
@@ -3615,6 +3622,8 @@ dec_as_long(PyObject *dec, PyObject *context, int round)
         mpd_del(x);
         return NULL;
     }
+
+    status = 0;
 #if PYLONG_BITS_IN_DIGIT == 30
     n = mpd_qexport_u32(&ob_digit, n, PyLong_BASE, x, &status);
 #elif PYLONG_BITS_IN_DIGIT == 15


### PR DESCRIPTION
Second commit (patch v2) has a quick path for int64_t-sized integers.

| Benchmark      | master  | patch                 | patch2               |
|----------------|:-------:|:---------------------:|:--------------------:|
| 1<<7           | 651 ns  | 658 ns: 1.01x slower  | 531 ns: 1.22x faster |
| 1<<38          | 747 ns  | 700 ns: 1.07x faster  | 533 ns: 1.40x faster |
| 1<<300         | 2.35 us | 2.32 us: 1.01x faster | not significant      |
| Geometric mean | (ref)   | 1.02x faster          | 1.15x faster         |

Benchmark hidden because not significant (1): 1<<3000

<details>

```py
import pyperf
from decimal import Decimal as D

runner = pyperf.Runner()
runner.bench_func('1<<7', int, D(1 << 7))
runner.bench_func('1<<38', int, D(1 << 38))
runner.bench_func('1<<300', int, D(1 << 300))
runner.bench_func('1<<3000', int, D(1 << 3000))
```

</details>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
